### PR TITLE
support the farmer plugin. implements #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ On first run, use DokuWiki's [installer](https://www.dokuwiki.org/installer) to 
 * xsendfile configured and enabled
 * imagemagick installed and enabled
 * nice URLs via rewriting configured and enabled
+* farming support via the [farmer plugin](https://www.dokuwiki.org/plugin:farmer)
 
 Note: This image does **not** include a mail server. You need to configure DokuWiki to use an external mail server, this
 most easily achieved using the [SMTP plugin](https://www.dokuwiki.org/plugin:smtp).
@@ -36,6 +37,12 @@ The container runs the standard production php.ini. Some options can be set via 
 * `PHP_TIMEZONE` - The timezone. Default `UTC`
 
 Custom PHP configuration values can be set in a `php.ini` file in the storage volume.
+
+## Farming
+
+This image supports farming via the [farmer plugin](https://www.dokuwiki.org/plugin:farmer). To use it, install the plugin and configure it as described in the plugin documentation. The initial farm configuration is already done in this image. The farm directory is `/storage/farm`.
+
+Use a reverse proxy to route animal requests to this container.
 
 ## How this image handles user data
 

--- a/root/etc/apache2/conf-available/dokuwiki.conf
+++ b/root/etc/apache2/conf-available/dokuwiki.conf
@@ -3,7 +3,7 @@
     AllowOverride All
 
     XSendFile on
-    XSendFilePath /storage/data/
+    XSendFilePath /storage/
 </Directory>
 
 <Files ~ "^([\._]ht|README$|VERSION$|COPYING$)">

--- a/root/var/www/html/.htaccess
+++ b/root/var/www/html/.htaccess
@@ -1,7 +1,12 @@
 # enable rewriting by default
-
 RewriteEngine on
 
+# Support the ! syntax for farm animals
+RewriteRule ^!([^/]+)/(.*)  $2?animal=$1 [QSA,DPI]
+RewriteRule ^!([^/]+)$      ?animal=$1 [QSA,DPI]
+Options +FollowSymLinks
+
+# pretty urls
 RewriteRule ^_media/(.*)              lib/exe/fetch.php?media=$1  [QSA,L]
 RewriteRule ^_detail/(.*)             lib/exe/detail.php?media=$1  [QSA,L]
 RewriteRule ^_export/([^/]+)/(.*)     doku.php?do=export_$1&id=$2  [QSA,L]

--- a/root/var/www/html/inc/preload.php
+++ b/root/var/www/html/inc/preload.php
@@ -1,33 +1,35 @@
 <?php
 
-/**
- * Read defaults from the core configuration directory
- *
- * @todo when #3760 is merged/addressed it should no longer be necessary to define
- *       DOKU_CONF and include config_cascade.php
- */
-if (!defined('DOKU_CONF')) define('DOKU_CONF', __DIR__ . '/../conf/');
-include __DIR__ . '/config_cascade.php';
-$config_cascade['main']['default'] = ['/var/www/html/conf.core/dokuwiki.php', '/var/www/html/conf.core/docker.php'];
-$config_cascade['main']['protected'] = [
-    DOKU_CONF . 'local.protected.php',
-    '/var/www/html/conf.core/docker.protected.php'
-];
-$config_cascade['acronyms']['default'] = ['/var/www/html/conf.core/acronyms.conf'];
-$config_cascade['entities']['default'] = ['/var/www/html/conf.core/entities.conf'];
-$config_cascade['interwiki']['default'] = ['/var/www/html/conf.core/interwiki.conf'];
-$config_cascade['license']['default'] = ['/var/www/html/conf.core/license.php'];
-$config_cascade['manifest']['default'] = ['/var/www/html/conf.core/manifest.json'];
-$config_cascade['mediameta']['default'] = ['/var/www/html/conf.core/mediameta.php'];
-$config_cascade['mime']['default'] = ['/var/www/html/conf.core/mime.conf'];
-$config_cascade['scheme']['default'] = ['/var/www/html/conf.core/scheme.conf'];
-$config_cascade['smileys']['default'] = ['/var/www/html/conf.core/smileys.conf'];
-$config_cascade['wordblock']['default'] = ['/var/www/html/conf.core/wordblock.conf'];
-$config_cascade['plugins']['default'] = ['/var/www/html/conf.core/plugins.php'];
-$config_cascade['plugins']['default'] = ['/var/www/html/conf.core/plugins.php'];
-$config_cascade['plugins']['protected'] = [
+// initialize the farm if the farmer plugin is available
+if (file_exists(__DIR__ . '/../lib/plugins/farmer/DokuWikiFarmCore.php')) {
+    $_ENV['DOKU_FARMDIR'] = '/storage/farm/';
+    include(__DIR__ . '/../lib/plugins/farmer/DokuWikiFarmCore.php');
+}
+
+// load the standard cascade if the farmer hasn't already loaded it
+if (!defined('DOKU_CONF')) {
+    define('DOKU_CONF', __DIR__ . '/../conf/');
+    include __DIR__ . '/config_cascade.php';
+}
+
+// adjust the previously set config_cascade
+array_unshift($config_cascade['main']['default'], '/var/www/html/conf.core/dokuwiki.php');
+array_push($config_cascade['main']['default'], '/var/www/html/conf.core/docker.php');
+array_unshift($config_cascade['main']['protected'], '/var/www/html/conf.core/docker.protected.php');
+array_unshift($config_cascade['acronyms']['default'], '/var/www/html/conf.core/acronyms.conf');
+array_unshift($config_cascade['entities']['default'], '/var/www/html/conf.core/entities.conf');
+array_unshift($config_cascade['interwiki']['default'], '/var/www/html/conf.core/interwiki.conf');
+array_unshift($config_cascade['license']['default'], '/var/www/html/conf.core/license.php');
+array_unshift($config_cascade['manifest']['default'], '/var/www/html/conf.core/manifest.json');
+array_unshift($config_cascade['mediameta']['default'], '/var/www/html/conf.core/mediameta.php');
+array_unshift($config_cascade['mime']['default'], '/var/www/html/conf.core/mime.conf');
+array_unshift($config_cascade['scheme']['default'], '/var/www/html/conf.core/scheme.conf');
+array_unshift($config_cascade['smileys']['default'], '/var/www/html/conf.core/smileys.conf');
+array_unshift($config_cascade['wordblock']['default'], '/var/www/html/conf.core/wordblock.conf');
+array_unshift($config_cascade['plugins']['default'], '/var/www/html/conf.core/plugins.php');
+array_unshift(
+    $config_cascade['plugins']['protected'],
     '/var/www/html/conf.core/plugins.required.php',
-    '/var/www/html/conf.core/plugins.docker.php',
-    DOKU_CONF . 'plugins.protected.php'
-];
+    '/var/www/html/conf.core/plugins.docker.php'
+);
 


### PR DESCRIPTION
This makes adjustments so that farming will automatically work as soon as the farmer plugin is installed. The setup step can be skipped and instead the plugin is preconfigured to use /storage/farm as farm dir.

!bang based animals are supported, but of course it makes more sense to use a host based setup with docker. With a reverse proxy in front of this image, it should be easy to point different host names at this image. However this has not been tested yet and might need additional adjustments in the farmer plugin.

A merge should only happen after this has been tested.