### PR TITLE
Feature/smileys

### DIFF
--- a/root/build-setup.sh
+++ b/root/build-setup.sh
@@ -35,6 +35,8 @@ mv /var/www/html/lib/plugins /var/www/html/lib/plugins.core
 ln -s /storage/lib/plugins /var/www/html/lib/plugins
 mv /var/www/html/lib/tpl /var/www/html/lib/tpl.core
 ln -s /storage/lib/tpl /var/www/html/lib/tpl
+mv /var/www/html/lib/images /var/www/html/lib/images.core
+ln -s /storage/lib/images /var/www/html/lib/images
 
 # delete all build files
 rm -- /build-*

--- a/root/build-setup.sh
+++ b/root/build-setup.sh
@@ -35,8 +35,8 @@ mv /var/www/html/lib/plugins /var/www/html/lib/plugins.core
 ln -s /storage/lib/plugins /var/www/html/lib/plugins
 mv /var/www/html/lib/tpl /var/www/html/lib/tpl.core
 ln -s /storage/lib/tpl /var/www/html/lib/tpl
-mv /var/www/html/lib/images /var/www/html/lib/images.core
-ln -s /storage/lib/images /var/www/html/lib/images
+mv /var/www/html/lib/images/smileys /var/www/html/lib/images/smileys.core
+ln -s /storage/lib/images/smileys /var/www/html/lib/images/smileys
 
 # delete all build files
 rm -- /build-*

--- a/root/dokuwiki-storagesetup.sh
+++ b/root/dokuwiki-storagesetup.sh
@@ -16,7 +16,7 @@ mkdir -p /storage/conf
 ln -s /var/www/html/conf.core/license.php /storage/conf/license.php
 
 # core extensions are symlinked to the volume
-for ext in plugins tpl; do
+for ext in plugins tpl images; do
   mkdir -p /storage/lib/$ext
   for dir in /var/www/html/lib/$ext.core/*; do
     base=$(basename $dir)

--- a/root/dokuwiki-storagesetup.sh
+++ b/root/dokuwiki-storagesetup.sh
@@ -16,7 +16,7 @@ mkdir -p /storage/conf
 ln -s /var/www/html/conf.core/license.php /storage/conf/license.php
 
 # core extensions are symlinked to the volume
-for ext in plugins tpl images; do
+for ext in plugins tpl; do
   mkdir -p /storage/lib/$ext
   for dir in /var/www/html/lib/$ext.core/*; do
     base=$(basename $dir)
@@ -26,4 +26,17 @@ for ext in plugins tpl images; do
     ln -s $dir /storage/lib/$ext/$base
   done
 done
+
+# smileys are symlinked to volume so they work per dokuwiki docs
+for ext in smileys; do
+  mkdir -p /storage/lib/images/$ext
+  for dir in /var/www/html/lib/images/$ext.core/*; do
+    base=$(basename $dir)
+    [ -d "/storage/lib/images/$ext/$base" ] && rm -r /storage/lib/images/$ext/$base
+    [ -f "/storage/lib/images/$ext/$base" ] && rm /storage/lib/images/$ext/$base
+    [ -L "/storage/lib/images/$ext/$base" ] && rm /storage/lib/images/$ext/$base
+    ln -s $dir /storage/lib/images/$ext/$base
+  done
+done
+
 

--- a/root/dokuwiki-storagesetup.sh
+++ b/root/dokuwiki-storagesetup.sh
@@ -16,7 +16,7 @@ mkdir -p /storage/conf
 ln -s /var/www/html/conf.core/license.php /storage/conf/license.php
 
 # core extensions are symlinked to the volume
-for ext in plugins tpl; do
+for ext in plugins tpl "images/smileys"; do
   mkdir -p /storage/lib/$ext
   for dir in /var/www/html/lib/$ext.core/*; do
     base=$(basename $dir)
@@ -26,17 +26,3 @@ for ext in plugins tpl; do
     ln -s $dir /storage/lib/$ext/$base
   done
 done
-
-# smileys are symlinked to volume so they work per dokuwiki docs
-for ext in smileys; do
-  mkdir -p /storage/lib/images/$ext
-  for dir in /var/www/html/lib/images/$ext.core/*; do
-    base=$(basename $dir)
-    [ -d "/storage/lib/images/$ext/$base" ] && rm -r /storage/lib/images/$ext/$base
-    [ -f "/storage/lib/images/$ext/$base" ] && rm /storage/lib/images/$ext/$base
-    [ -L "/storage/lib/images/$ext/$base" ] && rm /storage/lib/images/$ext/$base
-    ln -s $dir /storage/lib/images/$ext/$base
-  done
-done
-
-


### PR DESCRIPTION
### Goal
- Symlink smileys so they work as the docs state

### Relevant links
- [This PR is based off this forum dicussion](https://forum.dokuwiki.org/d/22513-symlink-lib-in-the-official-container)
- [Official docs on smileys](https://www.dokuwiki.org/smileys)

### Summary of changes
- mv original lib/images/smileys dir to lib/images/smileys.core like plugins, etc.
- extend loop for plugins,tpl to do same for images/smileys dir for symlink to /storage

### Testing
- I've tested this locally on a test instance of mine that was broken before (ie. I had smileys.local.conf from a custom smiley pack and the local images obviously were not picked up) and changed to this image and they worked again
- I would appreciate someone testing *more* against a test instance of their own to confirm that nothing is broken otherwise