### PR TITLE
allow compiling additional PHP extensions by build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8.2-apache AS dokuwiki-base
 
+# additional extensions can be passed as build-arg
+ARG PHP_EXTENSIONS=""
+
 COPY root/build-deps.sh /
 RUN /bin/bash /build-deps.sh
 

--- a/README.md
+++ b/README.md
@@ -89,5 +89,9 @@ To manually build the image:
 
     docker build --build-arg="DOKUWIKI_VERSION=stable" -t dokuwiki/dokuwiki:stable .
 
-Builds and deployments are currently done daily using
-the [GitHub Actions workflow](https://github.com/dokuwiki/docker/actions/workflows/docker.yml).
+Additional PHP extensions can be added to the image using the `PHP_EXTENSIONS` build argument. The value should be a space separated list of PHP extension names as understood by [docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer). For example:
+
+    docker build --build-arg="PHP_EXTENSIONS=pdo_pgsql pdo_mysql" -t dokuwiki/dokuwiki:stable .
+
+Builds are currently done daily using
+the [GitHub Actions workflow](https://github.com/dokuwiki/docker/actions/workflows/docker.yml) and new images are pushed for all upstream changes.

--- a/root/build-deps.sh
+++ b/root/build-deps.sh
@@ -18,8 +18,9 @@ apt-get autoclean
 curl -sSLf -o install-php-extensions \
      https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions
 chmod +x install-php-extensions
-./install-php-extensions gd bz2 opcache pdo_sqlite intl ldap
+./install-php-extensions gd bz2 opcache pdo_sqlite intl ldap $PHP_EXTENSIONS
 rm install-php-extensions
+php -m
 
 # remove package cache
 apt-get clean


### PR DESCRIPTION
This can be useful when for example databases need to be accessed by plugins.

@kossmac can you have a look at this?